### PR TITLE
resolve configure issue, include stdint, and resolve illegal instruction crash

### DIFF
--- a/simulation/src/applications/CMakeLists.txt
+++ b/simulation/src/applications/CMakeLists.txt
@@ -12,7 +12,7 @@ list(FILTER ASTRA_SIM_SOURCE_FILES EXCLUDE  REGEX ".*SimAiFlowModelRdma\\.cc")
 list(FILTER ASTRA_SIM_SOURCE_FILES EXCLUDE  REGEX ".*PhyMultiThread\\.cc")
 
 
-include_directories(${CMAKE_CURRENT_SOURCE_DIR})
+#include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 
 build_lib(
   LIBNAME applications

--- a/simulation/src/network/utils/bit-deserializer.h
+++ b/simulation/src/network/utils/bit-deserializer.h
@@ -23,6 +23,7 @@
 
 #include <vector>
 #include <deque>
+#include <cstdint>
 
 namespace ns3 {
 

--- a/simulation/src/network/utils/bit-serializer.h
+++ b/simulation/src/network/utils/bit-serializer.h
@@ -22,6 +22,7 @@
 #define BITSERIALIZER_H_
 
 #include <vector>
+#include <cstdint>
 
 namespace ns3 {
 

--- a/simulation/src/point-to-point/model/rdma-hw.cc
+++ b/simulation/src/point-to-point/model/rdma-hw.cc
@@ -403,6 +403,7 @@ int RdmaHw::SendPacketComplete(Ptr<Packet> p, CustomHeader &ch)
 	uint32_t nic_idx = GetNicIdxOfQp(qp);
 	Ptr<QbbNetDevice> dev = m_nic[nic_idx].dev;
 	SendComplete(qp);
+	return 0;
 }
 
 void RdmaHw::SendComplete(Ptr<RdmaQueuePair> qp)

--- a/simulation/src/wifi/model/block-ack-type.h
+++ b/simulation/src/wifi/model/block-ack-type.h
@@ -23,6 +23,7 @@
 
 #include <ostream>
 #include <vector>
+#include <cstdint>
 
 namespace ns3 {
 


### PR DESCRIPTION
Hi,

I had several issues with compilation. I resolved them as follows:

1. There is an error during ns3 configure due to cmakelists in src/applications. This error should now be resolved (in conjunction with the pull request on the main repository)
2. There were errors regarding undefined uint8_t and including stdint should resolve it
3. Missing return statement caused crashes especially when using multiple threads, gdb revealed the exact line that was causing this issue. Just added return 0 to a function in rdma-hw.cc