### PR TITLE
[Fix] In branch "Dev/qp" the config_8to1.sh missing "SEND_OUTPUT_FILE"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@
 .waf-1.7.11-*/
 .lock-waf_linux2_build
 simulation/build/ns3/*
+simulation/build/include/*
+simulation/build/src/*
 simulation/build/.wafpickle-*
 simulation/build/.old_srcdir
 simulation/build/scratch/*
@@ -25,6 +27,8 @@ simulation/.waf*-*
 simulation/cmake-cache/*
 simulation/cmake-cache/*
 simulation/.lock-ns3_linux_build
+simulation/.vscode
+simulation/.vscode/*
 
 analysis/*
 

--- a/simulation/examples/rdma-test/config_8to1.sh
+++ b/simulation/examples/rdma-test/config_8to1.sh
@@ -5,6 +5,7 @@ FLOW_FILE /ns-3-alibabacloud/simulation/examples/rdma-test/flows/8to1.txt
 # OUTPUT FILE PATH
 FCT_OUTPUT_FILE /ns-3-alibabacloud/simulation/examples/rdma-test/outputs/fct.txt
 PFC_OUTPUT_FILE /ns-3-alibabacloud/simulation/examples/rdma-test/outputs/pfc.txt
+SEND_OUTPUT_FILE /ns-3-alibabacloud/simulation/examples/rdma-test/outputs/send.txt
 
 # MONITOR SETTINGS
 QLEN_MON_FILE /ns-3-alibabacloud/simulation/examples/rdma-test/outputs/qlen.txt

--- a/simulation/scratch/common.h
+++ b/simulation/scratch/common.h
@@ -756,6 +756,7 @@ bool ReadConf(int argc, char *argv[]) {
     trace_output_file = get_output_file_name(config_file, trace_output_file);
     fct_output_file = get_output_file_name(config_file, fct_output_file);
     pfc_output_file = get_output_file_name(config_file, pfc_output_file);
+    send_output_file = get_output_file_name(config_file, send_output_file);
     qlen_mon_file = get_output_file_name(config_file, qlen_mon_file);
     bw_mon_file = get_output_file_name(config_file, bw_mon_file);
     rate_mon_file = get_output_file_name(config_file, rate_mon_file);

--- a/simulation/scratch/common.h
+++ b/simulation/scratch/common.h
@@ -756,7 +756,6 @@ bool ReadConf(int argc, char *argv[]) {
     trace_output_file = get_output_file_name(config_file, trace_output_file);
     fct_output_file = get_output_file_name(config_file, fct_output_file);
     pfc_output_file = get_output_file_name(config_file, pfc_output_file);
-    send_output_file = get_output_file_name(config_file, send_output_file);
     qlen_mon_file = get_output_file_name(config_file, qlen_mon_file);
     bw_mon_file = get_output_file_name(config_file, bw_mon_file);
     rate_mon_file = get_output_file_name(config_file, rate_mon_file);


### PR DESCRIPTION
<img width="658" alt="Screenshot 2025-03-14 at 18 11 06" src="https://github.com/user-attachments/assets/c7f7e31d-3361-470d-bb29-19e5d9150e7b" />

Noticed that you have a configuration options in `simulation/scratch/common.h` requires a file. This may not disturb the normal behavior or simulation results but I would like to modified it a little to avoid "Error: Empty File path."

Adding "SEND_OUTPUT_FILE" in config_8to1.sh to create an empty file. 