### PR TITLE
`QbbNetDevice::Resume` access `lastQp` only if the node type is NVSwitch

### DIFF
--- a/simulation/src/point-to-point/model/qbb-net-device.cc
+++ b/simulation/src/point-to-point/model/qbb-net-device.cc
@@ -460,9 +460,16 @@ namespace ns3 {
 		m_paused[qIndex] = false;
 		NS_LOG_INFO("Node " << m_node->GetId() << " dev " << m_ifIndex << " queue " << qIndex <<
 			" resumed at " << Simulator::Now().GetSeconds());
-		Ptr<RdmaQueuePair> lastQp = m_rdmaEQ->GetQp(qIndex);
-		if(lastQp->nvls_enable == 1 && m_node->GetNodeType() == 2) SwitchAsHostSend(); 
-		else DequeueAndTransmit();
+		if (m_node->GetNodeType() == 2) {
+            Ptr<RdmaQueuePair> lastQp = m_rdmaEQ->GetQp(qIndex);
+            if(lastQp->nvls_enable == 1) {
+				SwitchAsHostSend();
+			} else {
+				DequeueAndTransmit();
+			}
+        } else {
+			DequeueAndTransmit();
+		}
 	}
 
 	void


### PR DESCRIPTION
Previously, when sending a PFC Resume in `QbbNetDevice`, `lastQp` was accessed even on non-NVSwitch nodes, leading to an invalid access at `qIndex=3` and crashing the simulation.

The fix ensures that NVLS on the QP is checked and accessed only when the node type is 2. For other node types, the code now correctly falls back to `DequeueAndTransmit()`, without checking the QP.